### PR TITLE
NEOとしぃペインターの時は、Windows　inkや2本指のジェスチャーによるブラウザバックを無効にする。

### DIFF
--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -31,6 +31,7 @@
 		<script src="chickenpaint/js/chickenpaint.min.js<% def(parameter_day) %>?<% echo(parameter_day)%><% /def %>"></script>
 		<link rel="stylesheet" type="text/css" href="chickenpaint/css/chickenpaint.css<% def(parameter_day) %>?<% echo(parameter_day)%><% /def %>">
 		<% elsedef %>
+		<style>body{overscroll-behavior-x: none !important; }</style>
 		<script>
 			function cheerpJLoad() {
 			var jEnabled = navigator.javaEnabled();


### PR DESCRIPTION
デジタルインク(windows Ink)使用時の問題について · Issue #65 · funige/neo
https://github.com/funige/neo/issues/65
をcssでfix。
Windows inkだけの問題ではなく、AndroidやiOSの二本指ジェスチャーによるブラウザバックと問題は同じ。
[【HTML/CSS】Chromeで二本指スワイプした際に起こる「戻る」「進む」を無効化する - Qiita](https://qiita.com/sola-msr/items/83df3d20d5ccdd907186)
ChickenPaintは、iPadで前の画面に戻る時にジェスチャーが必要なので、この処理はNEOとしぃペインターのみ。
また、Paint画面以外には使いません。