### PR TITLE
document.write廃止。

### DIFF
--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -7,7 +7,10 @@
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;

--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -15,6 +15,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("CSSIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -145,5 +146,9 @@
 				</p>
 			</article>		
 		</footer>
+		<script>
+		let CSSIdx=GetCookie('CSSIdx');
+		document.getElementById("mystyle").selectedIndex=CSSIdx;
+		</script>
 	</body>
 </html>

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -7,7 +7,10 @@
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
@@ -285,12 +288,8 @@
 							<% /def %>
 							<% def(sharebutton) %>
 							<span class="share_button">
-								<script>
-									(function(){
-										var url = encodeURIComponent('<% echo(rooturl) %><% echo(self) %>?res=<% echo(oya/no) %>'); //ページURL。一応エンコード
-										var title = encodeURIComponent('[<% echo(oya/no) %>] <% echo(oya/sub) %> by <% echo(oya/name) %> - <% echo(title) %>'); //ページタイトル。同上。
-									document.write( '<a target="_blank" href="https://twitter.com/intent/tweet?&text=' + title + '&url=' + url + '"><span class="icon-twitter button"><img src="<% echo(skindir) %>img/twitter.svg" alt=""> tweet</span></a> <a target="_blank" class="fb btn" href="http://www.facebook.com/share.php?u=' + url + '"><span class="icon-facebook2 button"><img src="<% echo(skindir) %>img/facebook.svg" alt=""> share</span></a>' );})();
-								</script>
+								<a target="_blank" href="https://twitter.com/intent/tweet?text=[<% echo(oya/no|urlencode) %>] <% echo(oya/sub|urlencode) %> by <% echo(oya/name|urlencode) %> - <% echo(title|urlencode) %>&url=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-twitter button"><img src="<% echo(skindir) %>img/twitter.svg" alt=""> tweet</span></a>
+								<a target="_blank" class="fb btn" href="http://www.facebook.com/share.php?u=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-facebook2 button"><img src="<% echo(skindir) %>img/facebook.svg" alt=""> share</span></a>
 							</span>
 							<% /def %>
 							<% def(notres) %><span class="button"><a href="<% echo(self) %>?res=<% echo(oya/no) %>"><img src="<% echo(skindir) %>img/rep.svg" alt=""> 返信</a></span> <a href="#header" title="一番上へ">[↑]</a><% /def %>

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -15,6 +15,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("CSSIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -394,6 +395,8 @@
 					$(this).closest('form').submit();
 				});
 			});
+		let CSSIdx=GetCookie('CSSIdx');
+		document.getElementById("mystyle").selectedIndex=CSSIdx;
 		</script>
 	</body>
 </html>

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -15,6 +15,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("CSSIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -7,7 +7,10 @@
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -57,6 +57,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("CSSIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -49,7 +49,10 @@
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;

--- a/theme_monodev/search.html
+++ b/theme_monodev/search.html
@@ -6,7 +6,10 @@
 	<script>
 		var css = GetCookie("CSS");
 		if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-		document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+		var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 		function SetCss(file){
 			SetCookie("CSS", file);
 			window.location.reload();


### PR DESCRIPTION
document.writeを別の書き方に変更しました。
[HTML5でdocument.writeが非推奨であるならば – WEB制作システム](https://wps.wccp-tribeca.com/?p=1542)
SNS連携のエンコードはSkinnyの修飾子でエンコード。
CSSの出力は、`document.createElement`。
![image](https://user-images.githubusercontent.com/44894014/122097266-745bb100-ce4a-11eb-81ec-48f1858d0e12.png)
色を選択したあと、プルダウンメニューがcolorに戻っていたので、Cookieに保存して、選択中の色がselectedになるように改良しました。
上のほうのscriptでは対応できないため、
かなり下の方にそのためのscriptを追加しています。