### PR TITLE
document.write廃止。colorのプルダウンメニューのselectedをCookieに保存。

### DIFF
--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -7,7 +7,10 @@
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;

--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -103,7 +103,7 @@
 						<label>[<input type="checkbox" name="onlyimgdel" value="on">ImageOnly]</label>
 						<input class="button" type="submit" value=" OK ">
 						<span class="stylechanger">
-							<select class="form" name="select" id="mystyle" onchange="SetCss(this);">
+							<select class="form" id="mystyle" onchange="SetCss(this);">
 								<option value="<% echo(skindir) %>css/mono_dev.min.css">Color</option>
 								<option value="<% echo(skindir) %>css/mono_dev.min.css">DEV</option>
 								<option value="<% echo(skindir) %>css/mono_main.min.css">MONO</option>

--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -25,7 +25,7 @@
 					tmp = tmp.substring(tmp1, tmp.length);
 					var start = tmp.indexOf("=", 0) + 1;
 					var end = tmp.indexOf(";", start);
-					return(unescape(tmp.substring(start,end)));
+					return(decodeURIComponent(tmp.substring(start,end)));
 					}
 				return("");
 			}

--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -15,6 +15,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("CSSIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -145,5 +146,9 @@
 				</p>
 			</article>		
 		</footer>
+		<script>
+		let CSSIdx=GetCookie('CSSIdx');
+		document.getElementById("mystyle").selectedIndex=CSSIdx;
+		</script>
 	</body>
 </html>

--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -15,7 +15,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
-				SetCookie("CSSIdx",idx);
+				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -147,8 +147,8 @@
 			</article>		
 		</footer>
 		<script>
-		let CSSIdx=GetCookie('CSSIdx');
-		document.getElementById("mystyle").selectedIndex=CSSIdx;
+		let colorIdx=GetCookie('colorIdx');
+		document.getElementById("mystyle").selectedIndex=colorIdx;
 		</script>
 	</body>
 </html>

--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -4,18 +4,18 @@
 		<meta charset="<% echo(charset) %>">
 		<title><% echo(title) %></title>
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		<style>body{display: none;} </style>
 		<script>
-			var css = GetCookie("CSS");
+			let css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			var link = document.createElement("link");
-			link.rel = "stylesheet";
-			link.href =  css ;
-			document.getElementsByTagName("head")[0].appendChild(link);
-			function SetCss(obj){
-				var idx = obj.selectedIndex;
-				file = obj.options[idx].value;
+			const link = document.createElement("link");
+				link.rel = "stylesheet";
+				link.href =  css ;
+				link.addEventListener('load', () => {
+				document.getElementsByTagName("body")[0].style.display = "initial";});
+				document.getElementsByTagName("head")[0].appendChild(link);
+			function SetCss(file){
 				SetCookie("CSS", file);
-				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -34,9 +34,10 @@
 			}
 		</script>
 		<noscript>
+			<style>body{display: initial;} </style>
 			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
 		</noscript>
-	</head>
+		</head>
 	<body>
 		<header>
 			<h1><a href="<% echo(self2) %>"><% echo(title) %></a></h1>

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -344,7 +344,7 @@
 						<label>[<input type="checkbox" name="onlyimgdel" value="on">ImageOnly]</label>
 						<input class="button" type="submit" value=" OK ">
 						<span class="stylechanger">
-							<select class="form" name="select" id="mystyle" onchange="SetCss(this);">
+							<select class="form" id="mystyle" onchange="SetCss(this);">
 								<option value="<% echo(skindir) %>css/mono_dev.min.css">Color</option>
 								<option value="<% echo(skindir) %>css/mono_dev.min.css">DEV</option>
 								<option value="<% echo(skindir) %>css/mono_main.min.css">MONO</option>

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -7,7 +7,10 @@
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
@@ -285,12 +288,8 @@
 							<% /def %>
 							<% def(sharebutton) %>
 							<span class="share_button">
-								<script>
-									(function(){
-										var url = encodeURIComponent('<% echo(rooturl) %><% echo(self) %>?res=<% echo(oya/no) %>'); //ページURL。一応エンコード
-										var title = encodeURIComponent('[<% echo(oya/no) %>] <% echo(oya/sub) %> by <% echo(oya/name) %> - <% echo(title) %>'); //ページタイトル。同上。
-									document.write( '<a target="_blank" href="https://twitter.com/intent/tweet?&text=' + title + '&url=' + url + '"><span class="icon-twitter button"><img src="<% echo(skindir) %>img/twitter.svg" alt=""> tweet</span></a> <a target="_blank" class="fb btn" href="http://www.facebook.com/share.php?u=' + url + '"><span class="icon-facebook2 button"><img src="<% echo(skindir) %>img/facebook.svg" alt=""> share</span></a>' );})();
-								</script>
+								<a target="_blank" href="https://twitter.com/intent/tweet?text=[<% echo(oya/no|urlencode) %>] <% echo(oya/sub|urlencode) %> by <% echo(oya/name|urlencode) %> - <% echo(title|urlencode) %>&url=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-twitter button"><img src="<% echo(skindir) %>img/twitter.svg" alt=""> tweet</span></a>
+								<a target="_blank" class="fb btn" href="http://www.facebook.com/share.php?u=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-facebook2 button"><img src="<% echo(skindir) %>img/facebook.svg" alt=""> share</span></a>
 							</span>
 							<% /def %>
 							<% def(notres) %><span class="button"><a href="<% echo(self) %>?res=<% echo(oya/no) %>"><img src="<% echo(skindir) %>img/rep.svg" alt=""> 返信</a></span> <a href="#header" title="一番上へ">[↑]</a><% /def %>

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -4,18 +4,18 @@
 		<meta charset="<% echo(charset) %>">
 		<title><% echo(title) %></title>
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		<style>body{display: none;} </style>
 		<script>
-			var css = GetCookie("CSS");
+			let css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			var link = document.createElement("link");
-			link.rel = "stylesheet";
-			link.href =  css ;
-			document.getElementsByTagName("head")[0].appendChild(link);
-			function SetCss(obj){
-				var idx = obj.selectedIndex;
-				file = obj.options[idx].value;
+			const link = document.createElement("link");
+				link.rel = "stylesheet";
+				link.href =  css ;
+				link.addEventListener('load', () => {
+				document.getElementsByTagName("body")[0].style.display = "initial";});
+				document.getElementsByTagName("head")[0].appendChild(link);
+			function SetCss(file){
 				SetCookie("CSS", file);
-				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -34,9 +34,10 @@
 			}
 		</script>
 		<noscript>
+			<style>body{display: initial;} </style>
 			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
 		</noscript>
-		<% def(notres) %>
+			<% def(notres) %>
 		<% def(n) %>
 		このあたりは各自変更してもらえると嬉しいです
 		詳しい意味はgoogle先生に訊いてください。

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -25,7 +25,7 @@
 					tmp = tmp.substring(tmp1, tmp.length);
 					var start = tmp.indexOf("=", 0) + 1;
 					var end = tmp.indexOf(";", start);
-					return(unescape(tmp.substring(start,end)));
+					return(decodeURIComponent(tmp.substring(start,end)));
 					}
 				return("");
 			}

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -15,6 +15,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("CSSIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -394,6 +395,8 @@
 					$(this).closest('form').submit();
 				});
 			});
+		let CSSIdx=GetCookie('CSSIdx');
+		document.getElementById("mystyle").selectedIndex=CSSIdx;
 		</script>
 	</body>
 </html>

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -15,7 +15,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
-				SetCookie("CSSIdx",idx);
+				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -395,8 +395,8 @@
 					$(this).closest('form').submit();
 				});
 			});
-		let CSSIdx=GetCookie('CSSIdx');
-		document.getElementById("mystyle").selectedIndex=CSSIdx;
+		let colorIdx=GetCookie('colorIdx');
+		document.getElementById("mystyle").selectedIndex=colorIdx;
 		</script>
 	</body>
 </html>

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -15,6 +15,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("CSSIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -7,7 +7,10 @@
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -25,7 +25,7 @@
 					tmp = tmp.substring(tmp1, tmp.length);
 					var start = tmp.indexOf("=", 0) + 1;
 					var end = tmp.indexOf(";", start);
-					return(unescape(tmp.substring(start,end)));
+					return(decodeURIComponent(tmp.substring(start,end)));
 					}
 				return("");
 			}

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -15,7 +15,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
-				SetCookie("CSSIdx",idx);
+				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -4,18 +4,18 @@
 		<meta charset="<% echo(charset) %>">
 		<title><% echo(title) %></title>
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		<style>body{display: none;} </style>
 		<script>
-			var css = GetCookie("CSS");
+			let css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			var link = document.createElement("link");
-			link.rel = "stylesheet";
-			link.href =  css ;
-			document.getElementsByTagName("head")[0].appendChild(link);
-			function SetCss(obj){
-				var idx = obj.selectedIndex;
-				file = obj.options[idx].value;
+			const link = document.createElement("link");
+				link.rel = "stylesheet";
+				link.href =  css ;
+				link.addEventListener('load', () => {
+				document.getElementsByTagName("body")[0].style.display = "initial";});
+				document.getElementsByTagName("head")[0].appendChild(link);
+			function SetCss(file){
 				SetCookie("CSS", file);
-				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -34,9 +34,10 @@
 			}
 		</script>
 		<noscript>
+			<style>body{display: initial;} </style>
 			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
 		</noscript>
-	</head>
+		</head>
 	<body>
 		<header>
 			<h1><a href="<% echo(self2) %>"><% echo(title) %></a></h1>

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -67,7 +67,7 @@
 					tmp = tmp.substring(tmp1, tmp.length);
 					var start = tmp.indexOf("=", 0) + 1;
 					var end = tmp.indexOf(";", start);
-					return(unescape(tmp.substring(start,end)));
+					return(decodeURIComponent(tmp.substring(start,end)));
 					}
 				return("");
 			}

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -57,6 +57,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("CSSIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -54,18 +54,18 @@
 			window.addEventListener("load", function() { cheerpJLoad(); }, false);
 		</script>
 		<% /def %>
+		<style>body{display: none;} </style>
 		<script>
-			var css = GetCookie("CSS");
+			let css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			var link = document.createElement("link");
-			link.rel = "stylesheet";
-			link.href =  css ;
-			document.getElementsByTagName("head")[0].appendChild(link);
-			function SetCss(obj){
-				var idx = obj.selectedIndex;
-				file = obj.options[idx].value;
+			const link = document.createElement("link");
+				link.rel = "stylesheet";
+				link.href =  css ;
+				link.addEventListener('load', () => {
+				document.getElementsByTagName("body")[0].style.display = "initial";});
+				document.getElementsByTagName("head")[0].appendChild(link);
+			function SetCss(file){
 				SetCookie("CSS", file);
-				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -84,9 +84,10 @@
 			}
 		</script>
 		<noscript>
-			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_main.css" type="text/css">
+			<style>body{display: initial;} </style>
+			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
 		</noscript>
-	</head>
+		</head>
 	
 	<body id="paintmode">
 		<% def(chickenpaint)%>

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -57,7 +57,7 @@
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
-				SetCookie("CSSIdx",idx);
+				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -49,7 +49,10 @@
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -28,9 +28,6 @@
 			-ms-user-select: none;
 			user-select: none;
 		}
-		::selection {
-		background: transparent;
-		}
 		</style>
 		<script>
 		/* Check for native pointer event support before PEP adds its polyfill */

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -20,9 +20,19 @@
 		<link rel="stylesheet" href="neo.css<% def(parameter_day) %>?<% echo(parameter_day)%><% /def %>" type="text/css">
 		<script src="neo.js<% def(parameter_day) %>?<% echo(parameter_day)%><% /def %>"></script>
 		<% /def %>
-		<!-- Javaが使えるかどうか判定 使えなければcheerpJをロード -->
 		<% def(chickenpaint)%>
-		<script type="text/javascript">
+		<style>
+		div#chickenpaint-parent :not(input){
+			-moz-user-select: none;
+			-webkit-user-select: none;
+			-ms-user-select: none;
+			user-select: none;
+		}
+		::selection {
+		background: transparent;
+		}
+		</style>
+		<script>
 		/* Check for native pointer event support before PEP adds its polyfill */
 			if (window.PointerEvent) {
 				window.hasNativePointerEvents = true;
@@ -32,6 +42,7 @@
 		<link rel="stylesheet" type="text/css" href="chickenpaint/css/chickenpaint.css<% def(parameter_day) %>?<% echo(parameter_day)%><% /def %>">
 		<% elsedef %>
 		<style>body{overscroll-behavior-x: none !important; }</style>
+		<!-- Javaが使えるかどうか判定 使えなければcheerpJをロード -->
 		<script>
 			function cheerpJLoad() {
 			var jEnabled = navigator.javaEnabled();

--- a/theme_monodev/search.html
+++ b/theme_monodev/search.html
@@ -5,11 +5,13 @@
 	<meta name="viewport" content="width=device-width,initial-scale=1">
 	<style>body{display: none;} </style>
 	<script>
-		var css = GetCookie("CSS");
+		let css = GetCookie("CSS");
 		if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-		var link = document.createElement("link");
+		const link = document.createElement("link");
 			link.rel = "stylesheet";
 			link.href =  css ;
+			link.addEventListener('load', () => {
+			document.getElementsByTagName("body")[0].style.display = "initial";});
 			document.getElementsByTagName("head")[0].appendChild(link);
 		function SetCss(file){
 			SetCookie("CSS", file);
@@ -132,14 +134,6 @@
 	<div class="clear"></div>
 	</nav>
 </footer>
-<script>
-	//すべて読みこんでからbodyを表示
-	window.onload = function() {
-	document.getElementsByTagName("body")[0].style.display = "initial";
-	}
-</script>
-
-
 </div>
 </body>
 </html>

--- a/theme_monodev/search.html
+++ b/theme_monodev/search.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1">
+	<style>body{display: none;} </style>
 	<script>
 		var css = GetCookie("CSS");
 		if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
@@ -30,6 +31,7 @@
 		}
 	</script>
 	<noscript>
+		<style>body{display: inherit;} </style>
 		<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
 	</noscript>
 	<% def(imgsearch) %>
@@ -130,6 +132,13 @@
 	<div class="clear"></div>
 	</nav>
 </footer>
+<script>
+	//すべて読みこんでからbodyを表示
+	window.onload = function() {
+	document.getElementsByTagName("body")[0].style.display = "inherit";
+	}
+</script>
+
 
 </div>
 </body>

--- a/theme_monodev/search.html
+++ b/theme_monodev/search.html
@@ -31,7 +31,7 @@
 		}
 	</script>
 	<noscript>
-		<style>body{display: inherit;} </style>
+		<style>body{display: initial;} </style>
 		<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
 	</noscript>
 	<% def(imgsearch) %>
@@ -135,7 +135,7 @@
 <script>
 	//すべて読みこんでからbodyを表示
 	window.onload = function() {
-	document.getElementsByTagName("body")[0].style.display = "inherit";
+	document.getElementsByTagName("body")[0].style.display = "initial";
 	}
 </script>
 

--- a/theme_monodev/search.html
+++ b/theme_monodev/search.html
@@ -6,7 +6,10 @@
 	<script>
 		var css = GetCookie("CSS");
 		if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-		document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+		var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 		function SetCss(file){
 			SetCookie("CSS", file);
 			window.location.reload();

--- a/theme_monodev/search.html
+++ b/theme_monodev/search.html
@@ -21,7 +21,7 @@
 				tmp = tmp.substring(tmp1, tmp.length);
 				var start = tmp.indexOf("=", 0) + 1;
 				var end = tmp.indexOf(";", start);
-				return(unescape(tmp.substring(start,end)));
+				return(decodeURIComponent(tmp.substring(start,end)));
 				}
 			return("");
 		}


### PR DESCRIPTION
- document.writeを別の書き方に変更しました。
[HTML5でdocument.writeが非推奨であるならば – WEB制作システム](https://wps.wccp-tribeca.com/?p=1542)
SNS連携のエンコードはSkinnyの修飾子でエンコード。
CSSの出力は、`document.createElement`。
- 色を選択したあと、プルダウンメニューがcolorに戻っていたので、Cookieに保存して、選択中の色がselectedになるように改良しました。
![image](https://user-images.githubusercontent.com/44894014/122097266-745bb100-ce4a-11eb-81ec-48f1858d0e12.png)

上のほうのscriptでは対応できないため、
かなり下の方にそのためのscriptを追加しています。
- unescapeを別の関数に置き換え。
```

[unescape() - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/unescape)
警告: unescape() は厳密には (「ウェブ標準から削除された」という意味では) 非推奨になっていませんが、 ECMA-262 標準の Annex B において定義されており、導入部で次のように位置付けられています。
… この附属書で規定されているすべての言語機能および動作は、1つ以上の望ましくない特性を有しており、古い使用例がない場合には，この仕様から削除される。 …
```