### PR TITLE
ChickenPaintでペイント画面が選択される問題に対処

### DIFF
--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -4,14 +4,19 @@
 		<meta charset="<% echo(charset) %>">
 		<title><% echo(title) %></title>
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		  <link rel="stylesheet" href="<% echo(skindir) %>css/mono_main.min.css" type="text/css">
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -29,9 +34,7 @@
 				document.cookie = key + "=" + escape(val) + ";max-age=31536000;";
 			}
 		</script>
-		<noscript>
-			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
-		</noscript>
+	  
 	</head>
 	<body>
 		<header>
@@ -98,9 +101,8 @@
 						</select>
 						<label>[<input type="checkbox" name="onlyimgdel" value="on">ImageOnly]</label>
 						<input class="button" type="submit" value=" OK ">
-						<span class="stylechanger">
-							<select class="form" name="select" id="mystyle" onchange="SetCss(this);">
-								<option value="<% echo(skindir) %>css/mono_dev.min.css">Color</option>
+						<span class="stylechanger">Color: 
+							<select class="form" id="mystyle" onchange="SetCss(this);">
 								<option value="<% echo(skindir) %>css/mono_dev.min.css">DEV</option>
 								<option value="<% echo(skindir) %>css/mono_main.min.css">MONO</option>
 								<option value="<% echo(skindir) %>css/mono_dark.min.css">dark</option>
@@ -142,5 +144,9 @@
 				</p>
 			</article>		
 		</footer>
+		<script>
+			let colorIdx=GetCookie('colorIdx');
+			document.getElementById("mystyle").selectedIndex=colorIdx;
+		</script>
 	</body>
 </html>

--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -21,7 +21,7 @@
 					tmp = tmp.substring(tmp1, tmp.length);
 					var start = tmp.indexOf("=", 0) + 1;
 					var end = tmp.indexOf(";", start);
-					return(unescape(tmp.substring(start,end)));
+					return(decodeURIComponent(tmp.substring(start,end)));
 					}
 				return("");
 			}

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -4,14 +4,19 @@
 		<meta charset="<% echo(charset) %>">
 		<title><% echo(title) %></title>
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		  <link rel="stylesheet" href="<% echo(skindir) %>css/mono_main.min.css" type="text/css">
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -29,9 +34,7 @@
 				document.cookie = key + "=" + escape(val) + ";max-age=31536000;";
 			}
 		</script>
-		<noscript>
-			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
-		</noscript>
+	  
 		<% def(notres) %>
 		<% def(n) %>
 		このあたりは各自変更してもらえると嬉しいです
@@ -285,12 +288,8 @@
 							<% /def %>
 							<% def(sharebutton) %>
 							<span class="share_button">
-								<script>
-									(function(){
-										var url = encodeURIComponent('<% echo(rooturl) %><% echo(self) %>?res=<% echo(oya/no) %>'); //ページURL。一応エンコード
-										var title = encodeURIComponent('[<% echo(oya/no) %>] <% echo(oya/sub) %> by <% echo(oya/name) %> - <% echo(title) %>'); //ページタイトル。同上。
-									document.write( '<a target="_blank" href="https://twitter.com/intent/tweet?&text=' + title + '&url=' + url + '"><span class="icon-twitter button"><img src="<% echo(skindir) %>img/twitter.svg" alt=""> tweet</span></a> <a target="_blank" class="fb btn" href="http://www.facebook.com/share.php?u=' + url + '"><span class="icon-facebook2 button"><img src="<% echo(skindir) %>img/facebook.svg" alt=""> share</span></a>' );})();
-								</script>
+							<a target="_blank" href="https://twitter.com/intent/tweet?&text=%5B<% echo(oya/no|urlencode) %>%5D <% echo(oya/sub|urlencode) %> by <% echo(oya/name|urlencode) %> - <% echo(title|urlencode) %>&url=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-twitter button"><img src="<% echo(skindir) %>img/twitter.svg" alt=""> tweet</span></a>
+							<a target="_blank" class="fb btn" href="http://www.facebook.com/share.php?u=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-facebook2 button"><img src="<% echo(skindir) %>img/facebook.svg" alt=""> share</span></a>
 							</span>
 							<% /def %>
 							<% def(notres) %><span class="button"><a href="<% echo(self) %>?res=<% echo(oya/no) %>"><img src="<% echo(skindir) %>img/rep.svg" alt=""> 返信</a></span> <a href="#header" title="一番上へ">[↑]</a><% /def %>
@@ -343,9 +342,8 @@
 						</select>
 						<label>[<input type="checkbox" name="onlyimgdel" value="on">ImageOnly]</label>
 						<input class="button" type="submit" value=" OK ">
-						<span class="stylechanger">
-							<select class="form" name="select" id="mystyle" onchange="SetCss(this);">
-								<option value="<% echo(skindir) %>css/mono_dev.min.css">Color</option>
+						<span class="stylechanger">Color: 
+							<select class="form" id="mystyle" onchange="SetCss(this);">
 								<option value="<% echo(skindir) %>css/mono_dev.min.css">DEV</option>
 								<option value="<% echo(skindir) %>css/mono_main.min.css">MONO</option>
 								<option value="<% echo(skindir) %>css/mono_dark.min.css">dark</option>
@@ -395,6 +393,8 @@
 					$(this).closest('form').submit();
 				});
 			});
+			let colorIdx=GetCookie('colorIdx');
+			document.getElementById("mystyle").selectedIndex=colorIdx;
 		</script>
 	</body>
 </html>

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -21,7 +21,7 @@
 					tmp = tmp.substring(tmp1, tmp.length);
 					var start = tmp.indexOf("=", 0) + 1;
 					var end = tmp.indexOf(";", start);
-					return(unescape(tmp.substring(start,end)));
+					return(decodeURIComponent(tmp.substring(start,end)));
 					}
 				return("");
 			}

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -4,14 +4,19 @@
 		<meta charset="<% echo(charset) %>">
 		<title><% echo(title) %></title>
 		<meta name="viewport" content="width=device-width,initial-scale=1">
+		  <link rel="stylesheet" href="<% echo(skindir) %>css/mono_main.min.css" type="text/css">
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -29,9 +34,7 @@
 				document.cookie = key + "=" + escape(val) + ";max-age=31536000;";
 			}
 		</script>
-		<noscript>
-			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
-		</noscript>
+	  
 	</head>
 	<body>
 		<header>

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -21,7 +21,7 @@
 					tmp = tmp.substring(tmp1, tmp.length);
 					var start = tmp.indexOf("=", 0) + 1;
 					var end = tmp.indexOf(";", start);
-					return(unescape(tmp.substring(start,end)));
+					return(decodeURIComponent(tmp.substring(start,end)));
 					}
 				return("");
 			}

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -54,14 +54,19 @@
 			window.addEventListener("load", function() { cheerpJLoad(); }, false);
 		</script>
 		<% /def %>
+		  <link rel="stylesheet" href="<% echo(skindir) %>css/mono_main.min.css" type="text/css">
 		<script>
 			var css = GetCookie("CSS");
 			if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-			document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
+			var link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href =  css ;
+			document.getElementsByTagName("head")[0].appendChild(link);
 			function SetCss(obj){
 				var idx = obj.selectedIndex;
 				file = obj.options[idx].value;
 				SetCookie("CSS", file);
+				SetCookie("colorIdx",idx);
 				window.location.reload();
 			}
 			function GetCookie(key){
@@ -79,10 +84,7 @@
 				document.cookie = key + "=" + escape(val) + ";max-age=31536000;";
 			}
 		</script>
-		<noscript>
-			<link rel="stylesheet" href="<% echo(skindir) %>css/mono_main.css" type="text/css">
-		</noscript>
-	</head>
+		</head>
 	
 	<body id="paintmode">
 		<% def(chickenpaint)%>

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -22,6 +22,14 @@
 		<% /def %>
 		<!-- Javaが使えるかどうか判定 使えなければcheerpJをロード -->
 		<% def(chickenpaint)%>
+		<style>
+			div#chickenpaint-parent :not(input){
+			-moz-user-select: none;
+			-webkit-user-select: none;
+			-ms-user-select: none;
+			user-select: none;
+			}
+		</style>
 		<script type="text/javascript">
 		/* Check for native pointer event support before PEP adds its polyfill */
 			if (window.PointerEvent) {
@@ -63,7 +71,7 @@
 					tmp = tmp.substring(tmp1, tmp.length);
 					var start = tmp.indexOf("=", 0) + 1;
 					var end = tmp.indexOf(";", start);
-					return(unescape(tmp.substring(start,end)));
+					return(decodeURIComponent(tmp.substring(start,end)));
 					}
 				return("");
 			}

--- a/theme_monodev/search.html
+++ b/theme_monodev/search.html
@@ -3,12 +3,19 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1">
+	  <link rel="stylesheet" href="<% echo(skindir) %>css/mono_main.min.css" type="text/css">
 	<script>
 		var css = GetCookie("CSS");
 		if(css == ""){css = "<% echo(skindir) %>css/mono_dev.min.css";}
-		document.write('<link rel="stylesheet" href="' + css + '" type="text/css">');
-		function SetCss(file){
+		var link = document.createElement("link");
+		link.rel = "stylesheet";
+		link.href =  css ;
+		document.getElementsByTagName("head")[0].appendChild(link);
+		function SetCss(obj){
+			var idx = obj.selectedIndex;
+			file = obj.options[idx].value;
 			SetCookie("CSS", file);
+			SetCookie("colorIdx",idx);
 			window.location.reload();
 		}
 		function GetCookie(key){
@@ -26,9 +33,6 @@
 			document.cookie = key + "=" + escape(val) + ";max-age=31536000;";
 		}
 	</script>
-	<noscript>
-		<link rel="stylesheet" href="<% echo(skindir) %>css/mono_dev.min.css" type="text/css">
-	</noscript>
 	<% def(imgsearch) %>
 	<% else %>
 	<style>

--- a/theme_monodev/search.html
+++ b/theme_monodev/search.html
@@ -18,7 +18,7 @@
 				tmp = tmp.substring(tmp1, tmp.length);
 				var start = tmp.indexOf("=", 0) + 1;
 				var end = tmp.indexOf(";", start);
-				return(unescape(tmp.substring(start,end)));
+				return(decodeURIComponent(tmp.substring(start,end)));
 				}
 			return("");
 		}


### PR DESCRIPTION
前回のプルリクの内容は破棄し最低限必要と思われる箇所のみ変更しました。
ペイント画面に
```
		<style>
			div#chickenpaint-parent :not(input){
			-moz-user-select: none;
			-webkit-user-select: none;
			-ms-user-select: none;
			user-select: none;
			}
		</style>

```
を追加。
[WebKit/Chromium ベースのブラウザーは、仕様書に書かれている動作に従わず、このプロパティを継承するように実装しており](https://developer.mozilla.org/ja/docs/Web/CSS/user-select)
最初から、ChickenPaintの描画領域全体に`user-select: none;`が適用されているようにChromeではみえるものの、
Firefoxで確認すると`user-select: none;`が適用されていない。
`div#chickenpaint-parent :not(input)`とすれば`user-select: none;`が適用される。

[Release POTI-board EVO v3.02.0 · satopian/poti-kaini](https://github.com/satopian/poti-kaini/releases/tag/v3.02.0)

>  ChickenPaintの画面が選択されてしまう問題に対処  
>  
> ![image](https://user-images.githubusercontent.com/44894014/122634662-6b086800-d11a-11eb-83c0-25ab590cf7a1.png)
>   
> iPadなどで、ChickenPaintの画面が選択されてしまうのを防ぐため、CSSで対処しました。
> ペイント画面のHTMLの上書きアップデートが必要です。
> 

`unescape`は
[unescape() - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/unescape)
で、非推奨となってるため、`decodeURIComponent`に置き換え。
[Document.write() - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/Document/write)
Document.write()は、MDNではとくに警告がでていないので、そのままにしておきました。
その他の動作の変更なども今回のプルリクには含まれていません。
iPadユーザーから、画面が選択されてしまうから使えないのでなんとかして欲しいという要望があった事への対処が今回のプルリクのメインです。
よろしくお願いします。