### PR TITLE
v3.05.0対応

### DIFF
--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -152,7 +152,6 @@
 					<ul>
 						<li>お絵かきできる画像のサイズは幅 300～<% echo (pmaxw) %>、高さ 300～<% echo (pmaxh) %>の範囲内です。</li>
 						<li>画像は幅 <% echo (maxw) %>px、高さ <% echo (maxh) %>pxを超えると縮小表示されます。</li>
-						<li>現状、ChickenPaintはPCにのみ対応しています。</li>
 						<% def(addinfo) %><% echo (addinfo) %><% /def %>
 					</ul>
 					<% /def %>
@@ -162,6 +161,7 @@
 				<% def(form) %>
 				<article>
 					<form action="<% echo(self) %>" method="post" enctype="multipart/form-data">
+						<input type="hidden" name="token" value="<% def(token) %><% echo(token) %><% /def %>">
 						<input type="hidden" name="mode" value="regist">
 						<% def(resno) %><input type="hidden" name="resto" value="<% echo(resno) %>"><% /def %>
 						<input type="hidden" name="MAX_FILE_SIZE" value="<% echo(maxbyte) %>">
@@ -298,8 +298,8 @@
 							<% /def %>
 							<% def(sharebutton) %>
 							<span class="share_button">
-							<a target="_blank" href="https://twitter.com/intent/tweet?&text=%5B<% echo(oya/no|urlencode) %>%5D <% echo(oya/sub|urlencode) %> by <% echo(oya/name|urlencode) %> - <% echo(title|urlencode) %>&url=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-twitter button"><img src="<% echo(skindir) %>img/twitter.svg" alt=""> tweet</span></a>
-							<a target="_blank" class="fb btn" href="http://www.facebook.com/share.php?u=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-facebook2 button"><img src="<% echo(skindir) %>img/facebook.svg" alt=""> share</span></a>
+								<a target="_blank" href="https://twitter.com/intent/tweet?&text=%5B<% echo(oya/no|urlencode) %>%5D%20<% echo(oya/sub|urlencode) %>%20by%20<% echo(oya/name|urlencode) %>%20-%20<% echo(title|urlencode) %>&url=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-twitter button"><img src="<% echo(skindir) %>img/twitter.svg" alt=""> tweet</span></a>
+								<a target="_blank" class="fb btn" href="http://www.facebook.com/share.php?u=<% echo(rooturl|urlencode) %><% echo(self|urlencode) %>?res=<% echo(oya/no|urlencode) %>"><span class="icon-facebook2 button"><img src="<% echo(skindir) %>img/facebook.svg" alt=""> share</span></a>
 							</span>
 							<% /def %>
 							<% def(notres) %><span class="button"><a href="<% echo(self) %>?res=<% echo(oya/no) %>"><img src="<% echo(skindir) %>img/rep.svg" alt=""> 返信</a></span> <a href="#header" title="一番上へ">[↑]</a><% /def %>

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -107,9 +107,6 @@
 			<section>
 				<div class="thread">
 					<h1 class="oekaki">投稿フォーム<% def(admin) %> - ADMIN MODE-<% /def %></h1>
-					<% def(admin) %>
-					<p>You are able to use html tags.</p>
-					<% /def %>
 					<% def(pictmp) %>
 					<div class="tmpimg">
 						<% def(notmp) %>
@@ -130,6 +127,8 @@
 					<hr class="hr">
 					<% def(ptime) %><p class="ptime">PaintTime : <% echo(ptime) %></p><% /def %>
 					<form class="" action="<% echo(self) %>" method="post" enctype="multipart/form-data">
+					<input type="hidden" name="token" value="<% def(token) %><% echo(token) %><% /def %>">
+
 						<table>
 							<tr>
 								<td>name<% def(usename) %><% echo(usename) %><% /def %></td>

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -142,7 +142,8 @@
 		
 				allowDownload: true,
 				resourcesRoot: "chickenpaint/",
-				disableBootstrapAPI: true
+				disableBootstrapAPI: true,
+				fullScreenMode: "auto"
 			});
 		})
 		</script>


### PR DESCRIPTION
CSRFトークン対応。
フォームのhiddenフィールドにトークンをセット。
config.phpでトークンのチェックが有効に設定されている時に必要。
tweetのリンクにスペースが入っていたのを修正(前回のプルリク時のこちらのミス)。
機能上問題ないものの、w3cのチェックではエラーになるため スペースを `%20`に変更。
ChickenPaintのスマホ対応。
Paint画面にスマホの時は自動で全画面表示に切り替わるようにする設定を追加。
mainのChickenPaintはPC用という説明を削除しました。
