### PR TITLE
fixに必要なJavaScriptが適切に入っていなかったのを修正。

### DIFF
--- a/theme_monodev/fix_chiken/fix.css
+++ b/theme_monodev/fix_chiken/fix.css
@@ -1,6 +1,0 @@
-:not(input),div#chickenpaint-parent :not(input) {
-    -moz-user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-}

--- a/theme_monodev/fix_chiken/fix.js
+++ b/theme_monodev/fix_chiken/fix.js
@@ -1,4 +1,0 @@
-function load() {
-	document.addEventListener("dblclick", function(e){ e.preventDefault();}, { passive: false });
-	}
-	window.onload = load;

--- a/theme_monodev/fix_chiken/fix.js
+++ b/theme_monodev/fix_chiken/fix.js
@@ -1,4 +1,4 @@
-/* Check for native pointer event support before PEP adds its polyfill */
-if (window.PointerEvent) {
-    window.hasNativePointerEvents = true;
-}
+function load() {
+	document.addEventListener("dblclick", function(e){ e.preventDefault();}, { passive: false });
+	}
+	window.onload = load;

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -22,8 +22,20 @@
 		<% /def %>
 		<!-- Javaが使えるかどうか判定 使えなければcheerpJをロード -->
 		<% def(chickenpaint)%>
-		<link rel="stylesheet" href="<% echo(skindir) %>fix_chiken/fix.css" type="text/css">
-		<script href="<% echo(skindir) %>fix_chiken/fix.js"></script>
+		<style>
+			:not(input),div#chickenpaint-parent :not(input){
+				-moz-user-select: none;
+				-webkit-user-select: none;
+				-ms-user-select: none;
+				user-select: none;
+			}
+		</style>
+		<script>
+			function load() {
+			document.addEventListener("dblclick", function(e){ e.preventDefault()}, { passive: false });
+			}
+			window.onload = load;
+		</script>
 		<script src="chickenpaint/js/chickenpaint.min.js<% def(parameter_day) %>?<% echo(parameter_day)%><% /def %>"></script>
 		<link rel="stylesheet" type="text/css" href="chickenpaint/css/chickenpaint.css<% def(parameter_day) %>?<% echo(parameter_day)%><% /def %>">
 		<% elsedef %>


### PR DESCRIPTION
**ダブルタップズーム対策のためのコード**
```
		<script>
			function load() {
			document.addEventListener("dblclick", function(e){ e.preventDefault()}, { passive: false });
			}
			window.onload = load;
		</script>

```
### fix_chiken/fix.js に入っていた間違ったコード
```
/* Check for native pointer event support before PEP adds its polyfill */
if (window.PointerEvent) {
    window.hasNativePointerEvents = true;
}

```
必要の無い古いコードを誤って外部js化していたため、書き直しました。
また、外部js化するべきという意見がありましたが、外部化すると古い内容のキャッシュを読み込んでしまいます。
neo.jsを更新しても、バージョンがあがらない事の対策として、時間または日付をクエリとして追加してキャッシュを防いでいますが、それと同じ対策が必要になってしまいます。
しかし、HTMLの中にJavaScriptが入っていればPaint画面を開いた時に即座に更新されます。
また、動作に関する問い合わせに対応する時に、外部jsに何が入っているのか確認しなくてもすみます。
｢fixという名前のついたjs｣があれば、｢きっと対策のためのJavaScriptが入っている｣と想像しますが、
今回のように｢間違ったコードが入っている｣といった事が起きます。
外部化されたjsは検証を難しくします。
繰り返しになりますが、今回のケースでは、外部化する時点で誤って別のコードを外部化していたため、fixに必要なコードは実際には入っていませんでした。