### PR TITLE
2重送信防止のJavaScriptのバグ修正。MSG046 パスワードが短すぎます。

### DIFF
--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -363,12 +363,15 @@
 		</footer>
 		<script src="<% echo(skindir) %>jquery-3.5.1.min.js"></script>
 		<script>
-			$(function(){//2度押し対策
-				$('[type="submit"]').click(function(){
+			window.onpageshow = function(){
+				var $btn = $('[type="submit"]');
+				//disbledを解除
+				$btn.prop('disabled', false);
+				$btn.click(function(){//送信ボタン2度押し対策
 					$(this).prop('disabled',true);
 					$(this).closest('form').submit();
 				});
-			});
+			}
 			colorIdx=GetCookie('colorIdx');
 			document.getElementById("mystyle").selectedIndex=colorIdx;
 		</script>

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -183,15 +183,6 @@
 						</ul>
 						<% /def %>
 					</form>
-					<script src="<% echo(skindir) %>jquery-3.5.1.min.js"></script>
-					<script>
-						$(function(){//2度押し対策
-							$('[type="submit"]').click(function(){
-								$(this).prop('disabled',true);
-								$(this).closest('form').submit();
-							});
-						});
-					</script>
 					<% def(regist) %>
 					<script type="text/javascript">
 						l(); //LoadCookie
@@ -336,12 +327,15 @@
 		</footer>
 		<script src="<% echo(skindir) %>jquery-3.5.1.min.js"></script>
 		<script>
-			$(function(){//2度押し対策
-				$('[type="submit"]').click(function(){
+			window.onpageshow = function(){
+				var $btn = $('[type="submit"]');
+				//disbledを解除
+				$btn.prop('disabled', false);
+				$btn.click(function(){//送信ボタン2度押し対策
 					$(this).prop('disabled',true);
 					$(this).closest('form').submit();
 				});
-			});
+			}
 		</script>
 	</body>
 </html>

--- a/theme_monodev/template_ini.php
+++ b/theme_monodev/template_ini.php
@@ -75,6 +75,7 @@ define('MSG042', "を読めません");
 define('MSG043', "を書けません");
 define('MSG044', "最大ログ数が設定されていないか、数字以外の文字列が入っています。[Either the MAX LOG is not set, or it contains a non-numeric string.]");
 define('MSG045', "アップロードペイントに対応していないファイルです。[This file does not supported by the ability to load uploaded files onto the canvas.]<br>対応フォーマットはpch、spch、chiです。[Supported formats are pch, spch and chi.]");
+define('MSG046', "パスワードが短すぎます。最低6文字。[The password is too short. At least 6 characters.]");
 
 //文字色テーブル '値[,名称]'
 $fontcolors = array('white,White'


### PR DESCRIPTION
2重送信防止のJavaScriptに復帰処理が入っていなかったため、ブラウザの戻るで戻った時にボタンが無効になったままでした。
問題の箇所のJavaScriptを修正しました。
パスワードが最低6文字必要になったためエラーメッセージを追加しました。