### PR TITLE
URL変更。'MSG047', "画像の幅と高さが大きすぎるため続行できません。[The size of the picture is t…

### DIFF
--- a/theme_monodev/monodev_catalog.html
+++ b/theme_monodev/monodev_catalog.html
@@ -96,7 +96,7 @@
 				<!-- 著作権表示 削除しないでください -->
 				<!-- GazouBBS v3.0 --><!-- ふたば改0.8 --><!-- POTI-board -->
 				<p>
-					<a href="https://pbbs.sakura.ne.jp/poti/" target="_top" title="POTI-board EVO <% echo(verlot) %>">POTI-board EVO <% echo(ver) %></a>
+					<a href="https://paintbbs.sakura.ne.jp/poti/" target="_top" title="POTI-board EVO <% echo(verlot) %>">POTI-board EVO <% echo(ver) %></a>
 					Web Style by <a href="https://dev.oekakibbs.net/" target="_top" title="MONO_DEV <% echo(tver) %>">MONO_DEV</a>
 				</p>
 				<p>

--- a/theme_monodev/monodev_main.html
+++ b/theme_monodev/monodev_main.html
@@ -335,7 +335,7 @@
 				<!-- 著作権表示 削除しないでください -->
 				<!-- GazouBBS v3.0 --><!-- ふたば改0.8 --><!-- POTI-board -->
 				<p>
-					<a href="https://pbbs.sakura.ne.jp/poti/" target="_top" title="POTI-board EVO <% echo(verlot) %>">POTI-board EVO <% echo(ver) %></a>
+					<a href="https://paintbbs.sakura.ne.jp/poti/" target="_top" title="POTI-board EVO <% echo(verlot) %>">POTI-board EVO <% echo(ver) %></a>
 					Web Style by <a href="https://dev.oekakibbs.net/" target="_top" title="MONO_DEV <% echo(tver) %>">MONO_DEV</a>
 				</p>
 				<p>

--- a/theme_monodev/monodev_other.html
+++ b/theme_monodev/monodev_other.html
@@ -301,7 +301,7 @@
 				<!-- 著作権表示 削除しないでください -->
 				<!-- GazouBBS v3.0 --><!-- ふたば改0.8 --><!-- POTI-board -->
 				<p>
-					<a href="https://pbbs.sakura.ne.jp/poti/" target="_top" title="POTI-board EVO <% echo(verlot) %>">POTI-board EVO <% echo(ver) %></a>
+					<a href="https://paintbbs.sakura.ne.jp/poti/" target="_top" title="POTI-board EVO <% echo(verlot) %>">POTI-board EVO <% echo(ver) %></a>
 					Web Style by <a href="https://dev.oekakibbs.net/" target="_top" title="MONO_DEV <% echo(tver) %>">MONO_DEV</a>
 				</p>
 				<p>

--- a/theme_monodev/monodev_paint.html
+++ b/theme_monodev/monodev_paint.html
@@ -602,7 +602,7 @@
 				<!-- 著作権表示 削除しないでください -->
 				<!-- GazouBBS v3.0 --><!-- ふたば改0.8 --><!-- POTI-board -->
 				<p>
-					<a href="https://pbbs.sakura.ne.jp/poti/" target="_top" title="POTI-board EVO <% echo(verlot) %>">POTI-board EVO <% echo(ver) %></a>
+					<a href="https://paintbbs.sakura.ne.jp/poti/" target="_top" title="POTI-board EVO <% echo(verlot) %>">POTI-board EVO <% echo(ver) %></a>
 					Web Style by <a href="https://dev.oekakibbs.net/" target="_top" title="MONO_DEV <% echo(tver) %>">MONO_DEV</a>
 				</p>
 				<p>

--- a/theme_monodev/template_ini.php
+++ b/theme_monodev/template_ini.php
@@ -76,6 +76,7 @@ define('MSG043', "を書けません");
 define('MSG044', "最大ログ数が設定されていないか、数字以外の文字列が入っています。[Either the MAX LOG is not set, or it contains a non-numeric string.]");
 define('MSG045', "アップロードペイントに対応していないファイルです。[This file does not supported by the ability to load uploaded files onto the canvas.]<br>対応フォーマットはpch、spch、chiです。[Supported formats are pch, spch and chi.]");
 define('MSG046', "パスワードが短すぎます。最低6文字。[The password is too short. At least 6 characters.]");
+define('MSG047', "画像の幅と高さが大きすぎるため続行できません。<br>[The size of the picture is too large. You can not continue.]");
 
 //文字色テーブル '値[,名称]'
 $fontcolors = array('white,White'


### PR DESCRIPTION
大きなサイズの画像から続きを描く時に、NEOはキャンバスサイズで画像が切れる形でサイズの範囲内に収まります。
しかし、ChickenPaintはChickenPaintが画像の幅と高さを計算しなおしてキャンバスサイズを決定します。
つまりChickenPaintで続きを描く時に、サイズ違反の画像を読み込む事になり、save.phpで画像の幅と高さのサイズ違反を検出してエラーにするようになると、画像は開く事ができて続きを描く事はできのに投稿できないという問題が発生します。
そのため時間をかけて描いたのに投稿できなくする形ではなく最初からエラーにするようになりました。
新規エラーメッセージMSG047の処理を追加しました。
MSG047のエラーメッセージをtemplate_ini.phpに追加しました。